### PR TITLE
🐛 Use correct operator for skipping customer expanding

### DIFF
--- a/src/FondOfSpryker/Zed/ProductListCompany/Business/Model/CustomerExpander.php
+++ b/src/FondOfSpryker/Zed/ProductListCompany/Business/Model/CustomerExpander.php
@@ -68,7 +68,7 @@ class CustomerExpander implements CustomerExpanderInterface
         }
 
         return count($customerProductListCollection->getBlacklistIds()) > 0
-            && count($customerProductListCollection->getWhitelistIds()) > 0;
+            || count($customerProductListCollection->getWhitelistIds()) > 0;
     }
 
     /**


### PR DESCRIPTION
- blacklist ids or whitelist ids must at least one item for skipping
- if both are empty, customer will expand with company lists